### PR TITLE
Add dataset mapping documentation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 - [ ] Understand the SFOE dataset
   - [x] Explore the repository `https://github.com/SFOE/sharedmobility`
   - [x] Identify available data formats (GBFS JSON API, providers CSV)
-  - [ ] Map dataset fields to dashboard needs
+  - [x] Map dataset fields to dashboard needs
     - `provider_id`, `pickup_type`, `vehicle_type`, `station_id`, `bike_id`,
       coordinates, availability flags, region and station details
   - [x] Check update frequency and access method

--- a/docs/dataset_mapping.md
+++ b/docs/dataset_mapping.md
@@ -1,0 +1,31 @@
+# Dataset Field Mapping
+
+This document links fields from the SFOE **sharedmobility** dataset to the features used in the demo dashboard under `visualization/modern-dashboard`.
+
+## Source
+
+The dataset is provided via the GBFS 2.3 API at [sharedmobility.ch/v2](https://sharedmobility.ch/v2/). For details about field additions see `sharedmobility/Additions to GBFS.md` in this repository.
+
+## Important Fields
+
+| Dataset Field | Purpose in Dashboard |
+|---------------|---------------------|
+| `provider_id` | Used to identify the mobility provider. Allows filtering by provider and is included in combined IDs (`station_id`, `bike_id`). |
+| `vehicle_type` | Determines the type of asset (Bike, E-Bike, Scooter, etc.). Controls marker style and statistics per vehicle category. |
+| `pickup_type` | Indicates whether vehicles are free-floating or station‑based. Drives display logic for markers. |
+| `station_id` | Unique ID for a station. Combined with `provider_id` in GBFS 2.0. Used to place station markers. |
+| `bike_id` | Unique ID for a single vehicle in `free_bike_status.json`. Required when showing individual bike positions. |
+| `lat` / `lon` | Geographic coordinates. Used to position markers on the map. |
+| `is_reserved` / `is_disabled` | Availability flags for free vehicles. Used to show only available assets. |
+| `num_bikes_available` / `num_docks_available` | Availability information for stations. Used in statistics widgets. |
+| `region_id` / `region_name` | Allows grouping stations/vehicles by region. Can be used for regional filters. |
+| `name`, `address`, `post_code` | Station details shown in popups or tooltips. |
+
+These fields cover the minimum needed to replace the current `generateMockVehicles()` data generator with real values.
+
+## Next Steps
+
+1. Use the REST API or GBFS endpoints to fetch the above fields.
+2. Convert the data to a common GeoJSON format or keep the GBFS structure.
+3. Update the frontend to read these fields instead of mock data.
+


### PR DESCRIPTION
## Summary
- document mapping of sharedmobility dataset fields to dashboard features
- mark mapping task as complete in TODO

## Testing
- `python3 scripts/fetch_sharedmobility.py` *(clones dataset repo successfully)*

------
https://chatgpt.com/codex/tasks/task_e_687fed4d644c832699568e79f89dc33d